### PR TITLE
[refactor] 유저 정보 쿠키로 관리 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "pokemon",
       "version": "0.1.0",
       "dependencies": {
+        "@tanstack/react-query": "^5.76.1",
         "dayjs": "^1.11.13",
         "next": "15.3.1",
         "react": "^19.0.0",
@@ -1101,6 +1102,32 @@
         "@tailwindcss/oxide": "4.1.4",
         "postcss": "^8.4.41",
         "tailwindcss": "4.1.4"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.76.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.76.0.tgz",
+      "integrity": "sha512-FN375hb8ctzfNAlex5gHI6+WDXTNpe0nbxp/d2YJtnP+IBM6OUm7zcaoCW6T63BawGOYZBbKC0iPvr41TteNVg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.76.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.76.1.tgz",
+      "integrity": "sha512-YxdLZVGN4QkT5YT1HKZQWiIlcgauIXEIsMOTSjvyD5wLYK8YVvKZUPAysMqossFJJfDpJW3pFn7WNZuPOqq+fw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.76.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.76.1",
     "dayjs": "^1.11.13",
     "next": "15.3.1",
     "react": "^19.0.0",

--- a/src/app/(page)/input/page.tsx
+++ b/src/app/(page)/input/page.tsx
@@ -7,14 +7,15 @@ import talkingText from "@constants/pokemon/talkingText.json";
 import { birthOptions, genderOptions } from "@constants/selectedOptions";
 import { SajuProfile } from "@custom-types/sajuProfile";
 import { BirthId, GenderId } from "@custom-types/SelectOption";
+import { setUserInfo } from "@services/userServices";
 import { formatCurrentDateTime, parseDateTimeString } from "@utils/dateUtils";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
-// ! 저장버튼 클릭했을 때 Local storage 저장
 
 function InputPage() {
   const [input, setInput] = useState("");
   const [birth, setBirth] = useState(formatCurrentDateTime());
+
   const [selectedGenderId, setSelectedGenderId] = useState<GenderId>(
     genderOptions[0].id
   );
@@ -41,7 +42,7 @@ function InputPage() {
     });
   }
 
-  function handleButtonClick() {
+  async function handleButtonClick() {
     const { year, month, day, hours, minutes } = parseDateTimeString(birth);
     const userInfo: SajuProfile = {
       id: Math.random().toString(36).substring(2, 10),
@@ -56,8 +57,9 @@ function InputPage() {
         calendarType: selectedBirthId,
       },
     };
-    //유저 인포를 로컬스토리지에 저장
-    localStorage.setItem("userInfo", JSON.stringify(userInfo));
+    //유저 인포를 쿠키에 저장하는 함수
+    await setUserInfo(userInfo);
+    // setUserInfo(userInfo);
     router.push("/result");
   }
 

--- a/src/app/(page)/result/page.tsx
+++ b/src/app/(page)/result/page.tsx
@@ -7,23 +7,31 @@ import { SajuProfile } from "@custom-types/sajuProfile";
 import usePokemonByIlju from "@hooks/usePokemonByIlju";
 import { getIljuByBirth } from "@lib/sajuUtils";
 import { useRouter } from "next/navigation";
+import { userInfo } from "os";
 import { useEffect, useMemo, useState } from "react";
 
 function ResultPage() {
-  // const [sajuInfo, setSajuInfo] = useState<SajuProfile | null>(null);
+  const [sajuInfo, setSajuInfo] = useState<SajuProfile | null>(null);
   const router = useRouter();
-  // const ilju = useMemo(() => {
-  //   if (!sajuInfo) return "";
-  //   const { year, month, day } = sajuInfo.birthday;
-  //   return getIljuByBirth(`${year}-${month}-${day}`);
-  // }, [sajuInfo]);
-  const ilju = "기유";
+  const ilju = useMemo(() => {
+    if (!sajuInfo) return "";
+    const { year, month, day } = sajuInfo.birthday;
+    return getIljuByBirth(`${year}-${month}-${day}`);
+  }, [sajuInfo]);
+  // const ilju = "기유";
   const { pokemons, iljuDetail, typeImages, refetchPokemonData } =
     usePokemonByIlju(ilju);
 
   useEffect(() => {
     console.log("hook이 실행되어 출력합니다.", pokemons);
   }, [pokemons]);
+  useEffect(() => {
+    const data = localStorage.getItem("userInfo");
+    if (data) {
+      const userInfo = JSON.parse(data);
+      setSajuInfo(userInfo);
+    }
+  }, []);
 
   return (
     <div className="min-h-screen bg-slate-100 border-t-4 border-black shadow-[inset_0_4px_8px_rgba(0,0,0,0.2)]">
@@ -32,7 +40,7 @@ function ResultPage() {
         <header className="w-full flex justify-between items-center px-6 py-4 fixed top-0 left-0 z-50">
           <div className="flex gap-2">
             <button
-              onClick={async () => await refetchPokemonData}
+              onClick={async () => await refetchPokemonData()}
               className="px-4 py-2 bg-red-500 text-white text-sm font-bold rounded-full border-2 border-black shadow-[2px_2px_0px_black] hover:bg-red-600"
             >
               🔁 다시 뽑기

--- a/src/app/(page)/result/page.tsx
+++ b/src/app/(page)/result/page.tsx
@@ -2,58 +2,28 @@
 import PokemonCard from "@components/pokemon/PokemonCard";
 import UserProfile from "@components/UserProfile";
 import { typeClassMap } from "@constants/pokemon/pokemonTypesColor";
-import { PokemonDetail } from "@custom-types/pokemonDetail";
 import { SajuProfile } from "@custom-types/sajuProfile";
-import { IljuDetailType } from "@lib/pokemon/getIljuDetail";
+import usePokemonByIlju from "@hooks/usePokemonByIlju";
 import { getIljuByBirth } from "@lib/sajuUtils";
-import {
-  getRandomPokemonByIlju,
-  getTypeImage,
-} from "@services/pokemonServices";
 import { useRouter } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 
 function ResultPage() {
-  const [sajuInfo, setSajuInfo] = useState<SajuProfile | null>(null);
-  const [pokemons, setPokemons] = useState<PokemonDetail[] | null>(null);
-  const [iljuDetail, setIljuDetail] = useState<IljuDetailType | null>(null);
-  const [typeImages, setTypeImages] = useState<string[]>([]);
+  // const [sajuInfo, setSajuInfo] = useState<SajuProfile | null>(null);
   const router = useRouter();
-  const ilju = useMemo(() => {
-    if (!sajuInfo) return "";
-    const { year, month, day } = sajuInfo.birthday;
-    return getIljuByBirth(`${year}-${month}-${day}`);
-  }, [sajuInfo]);
+  // const ilju = useMemo(() => {
+  //   if (!sajuInfo) return "";
+  //   const { year, month, day } = sajuInfo.birthday;
+  //   return getIljuByBirth(`${year}-${month}-${day}`);
+  // }, [sajuInfo]);
+  const ilju = "기유";
+  const { pokemons, iljuDetail, typeImages, refetchPokemonData } =
+    usePokemonByIlju(ilju);
 
   useEffect(() => {
-    //전역상태로 사용하는 방법으로 수정 필요
-    const data = localStorage.getItem("userInfo");
-    if (data) {
-      const userData = JSON.parse(data);
-      setSajuInfo(userData);
-    }
-  }, []);
-  useEffect(() => {
-    if (ilju) {
-      fetchPokemonData();
-    }
-  }, [ilju]);
+    console.log("hook이 실행되어 출력합니다.", pokemons);
+  }, [pokemons]);
 
-  async function fetchPokemonData() {
-    if (ilju) {
-      //리액트 쿼리로 수정 필요
-      const pokemonData = await getRandomPokemonByIlju(ilju);
-      const typeImages = await getTypeImage(pokemonData.iljuDetail.types);
-      console.log("typeImages", typeImages.typeImages);
-      console.log(pokemonData.iljuDetail);
-      setPokemons(pokemonData.pokemon);
-      setIljuDetail(pokemonData.iljuDetail);
-      setTypeImages(typeImages.typeImages);
-    }
-  }
-  useEffect(() => {
-    console.log(iljuDetail);
-  }, [iljuDetail]);
   return (
     <>
       {iljuDetail && (
@@ -64,7 +34,7 @@ function ResultPage() {
             <header className="w-full flex justify-between items-center px-6 py-4 fixed top-0 left-0 z-50">
               <div className="flex gap-2">
                 <button
-                  onClick={fetchPokemonData}
+                  onClick={async () => await refetchPokemonData}
                   className="px-4 py-2  backdrop-blur-md bg-white/30 rounded-full bg-gray-100 hover:bg-gray-200 text-sm"
                 >
                   🔁 다시 뽑기
@@ -80,15 +50,19 @@ function ResultPage() {
             <img src={"/pokeball.svg"} className="ml-auto" />
           </div>
           <div className="absolute top-2/5 left-1/2 transform -translate-x-1/2 -translate-y-1/2">
-            <UserProfile name={sajuInfo?.name} />
+            {/* <UserProfile name={sajuInfo?.name} /> */}
           </div>
           <div className="bg-gray-50">
             <div className="w-full flex gap-4 justify-center p-8 mt-16">
-              {typeImages.map((item, idx) => (
-                <span key={idx} className="inline-block px-3 py-1 rounded-full">
-                  <img src={item} className="w-20 h-auto" />
-                </span>
-              ))}
+              {Array.isArray(typeImages) &&
+                typeImages?.map((item, idx) => (
+                  <span
+                    key={idx}
+                    className="inline-block px-3 py-1 rounded-full"
+                  >
+                    <img src={item} className="w-20 h-auto" />
+                  </span>
+                ))}
             </div>
 
             {iljuDetail?.trait && (

--- a/src/app/(page)/result/page.tsx
+++ b/src/app/(page)/result/page.tsx
@@ -1,95 +1,34 @@
-"use client";
-import PokemonCard from "@components/pokemon/PokemonCard";
-import UserProfile from "@components/UserProfile";
-import { typeClassMap } from "@constants/pokemon/pokemonTypesColor";
-import { PokemonDetail } from "@custom-types/pokemonDetail";
-import { SajuProfile } from "@custom-types/sajuProfile";
-import usePokemonByIlju from "@hooks/usePokemonByIlju";
+import Button from "@components/Button";
+import TalkingBox from "@components/pokemon/TalkingBox";
+import ResultPage from "@components/ResultPage";
 import { getIljuByBirth } from "@lib/sajuUtils";
-import { useRouter } from "next/navigation";
-import { userInfo } from "os";
-import { useEffect, useMemo, useState } from "react";
+import { cookies } from "next/headers";
 
-function ResultPage() {
-  const [sajuInfo, setSajuInfo] = useState<SajuProfile | null>(null);
-  const router = useRouter();
-  const ilju = useMemo(() => {
-    if (!sajuInfo) return "";
-    const { year, month, day } = sajuInfo.birthday;
-    return getIljuByBirth(`${year}-${month}-${day}`);
-  }, [sajuInfo]);
-  // const ilju = "기유";
-  const { pokemons, iljuDetail, typeImages, refetchPokemonData } =
-    usePokemonByIlju(ilju);
+export default async function Result() {
+  //쿠키에서 유저 정보 가져옴
+  const raw = (await cookies()).get("userInfo")?.value;
+  const data = raw ? JSON.parse(raw) : null;
 
-  useEffect(() => {
-    console.log("hook이 실행되어 출력합니다.", pokemons);
-  }, [pokemons]);
-  useEffect(() => {
-    const data = localStorage.getItem("userInfo");
-    if (data) {
-      const userInfo = JSON.parse(data);
-      setSajuInfo(userInfo);
-    }
-  }, []);
-
-  return (
-    <div className="min-h-screen bg-slate-100 border-t-4 border-black shadow-[inset_0_4px_8px_rgba(0,0,0,0.2)]">
-      {/* 상단 헤더 + 배경 */}
-      <div className="relative w-full">
-        <header className="w-full flex justify-between items-center px-6 py-4 fixed top-0 left-0 z-50">
-          <div className="flex gap-2">
-            <button
-              onClick={async () => await refetchPokemonData()}
-              className="px-4 py-2 bg-red-500 text-white text-sm font-bold rounded-full border-2 border-black shadow-[2px_2px_0px_black] hover:bg-red-600"
-            >
-              🔁 다시 뽑기
-            </button>
-            <button
-              onClick={() => router.push("/input")}
-              className="px-4 py-2 bg-white text-black text-sm font-bold rounded-full border-2 border-black shadow-[2px_2px_0px_black] hover:bg-gray-100"
-            >
-              🏠 홈으로
-            </button>
+  if (!data) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-[#E11B1D]">
+        <TalkingBox
+          ment={[
+            "트레이너 정보를 확인할 수가 없다고 나오는군!\n다시 돌아가서 정보를 입력해주게나",
+          ]}
+        >
+          <div className="flex flex-col justify-center items-center">
+            <Button routerPath="/input" background="white">
+              ↩️ 돌아가기
+            </Button>
           </div>
-        </header>
-        <img src="/pokeball.svg" className="w-28 h-auto opacity-30" />
+        </TalkingBox>
       </div>
+    );
+  }
 
-      {/* 리포트 카드 */}
-      <div className="max-w-xl mx-auto mt-[-30px] bg-white border-2 border-black rounded-xl shadow-[4px_4px_0px_black] p-6 space-y-4 z-10 relative ">
-        {/* <UserProfile name={sajuInfo?.name} /> */}
-        <div className="w-full flex justify-center items-center p-4 ">
-          <img
-            src={`/pokeball_color.svg`}
-            alt="pokeball"
-            className="w-[180px] h-auto"
-          />
-        </div>
-        <div className="flex justify-center gap-2">
-          {Array.isArray(typeImages) &&
-            typeImages.map((img, idx) => (
-              <img key={idx} src={img} className="w-16 h-auto" />
-            ))}
-        </div>
-        <div className="text-center text-gray-800 text-base font-mono tracking-wide space-y-1">
-          {iljuDetail &&
-            iljuDetail.trait.map((trait, idx) => <p key={idx}>{trait}</p>)}
-        </div>
-      </div>
+  const { year, month, day } = data.birthday;
+  const ilju = getIljuByBirth(`${year}-${month}-${day}`);
 
-      {/* 추천 포켓몬 영역 */}
-      <div className="w-full mx-auto mt-12 px-4">
-        <h2 className="text-xl font-bold text-center mb-4  border-black pb-2 font-mono tracking-widest">
-          {/* {sajuInfo?.name}님과 어울리는 포켓몬 */}
-        </h2>
-        <div className="flex flex-wrap gap-8 items-center w-full justify-center">
-          {pokemons?.map((pokemon) => (
-            <PokemonCard key={pokemon.url} pokemon={pokemon} />
-          ))}
-        </div>
-      </div>
-    </div>
-  );
+  return <ResultPage ilju={ilju} username={data.name} />;
 }
-export default ResultPage;

--- a/src/app/api/user/route.ts
+++ b/src/app/api/user/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from "next/server";
+import { cookies } from "next/headers";
+
+//유저 정보를 받아서 쿠키에 저장
+export async function POST(request: NextRequest) {
+  const data = await request.json();
+
+  const cookieStore = await cookies();
+  cookieStore.set("userInfo", JSON.stringify(data), {
+    httpOnly: true,
+    path: "/",
+    maxAge: 60 * 60 * 24, // 1일 유지
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import QueryProvider from "@components/QueryProvider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -26,7 +27,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <QueryProvider>{children}</QueryProvider>
       </body>
     </html>
   );

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,31 @@
+"use client";
+import { useRouter } from "next/navigation";
+import { ReactNode } from "react";
+
+export default function Button({
+  children,
+  background,
+  onClick,
+  routerPath,
+}: {
+  children: ReactNode;
+  background: string;
+  onClick?: () => void;
+  routerPath?: string;
+}) {
+  const router = useRouter();
+  function handleButtonClick() {
+    if (onClick) {
+      onClick();
+    }
+    routerPath && router.push(routerPath);
+  }
+  return (
+    <button
+      onClick={handleButtonClick}
+      className={`px-4 py-2 bg-${background} text-black text-sm font-bold rounded-full border-2 border-black shadow-[2px_2px_0px_black] hover:bg-gray-100`}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,14 @@
+"use client";
+import Button from "@components/Button";
+import usePokemonByIlju from "@hooks/usePokemonByIlju";
+import useUserStore from "@store/userStore";
+import { useRouter } from "next/navigation";
+import { ReactNode } from "react";
+
+export default function Header({ children }: { children: ReactNode }) {
+  return (
+    <header className="w-full flex justify-between items-center px-6 py-4 fixed top-0 left-0 z-50">
+      <div className="flex gap-2">{children}</div>
+    </header>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,8 +1,3 @@
-"use client";
-import Button from "@components/Button";
-import usePokemonByIlju from "@hooks/usePokemonByIlju";
-import useUserStore from "@store/userStore";
-import { useRouter } from "next/navigation";
 import { ReactNode } from "react";
 
 export default function Header({ children }: { children: ReactNode }) {

--- a/src/components/QueryProvider.tsx
+++ b/src/components/QueryProvider.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+
+export default function QueryProvider({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient();
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}

--- a/src/components/ResultPage.tsx
+++ b/src/components/ResultPage.tsx
@@ -1,0 +1,65 @@
+"use client";
+import Button from "@components/Button";
+import Header from "@components/Header";
+import PokemonCard from "@components/pokemon/PokemonCard";
+import usePokemonByIlju from "@hooks/usePokemonByIlju";
+
+interface ResultPageProps {
+  ilju: string;
+  username: string;
+}
+export default function ResultPage({ ilju, username }: ResultPageProps) {
+  const { pokemons, iljuDetail, typeImages, refetchPokemonData } =
+    usePokemonByIlju(ilju);
+
+  return (
+    <div className="flex flex-col min-h-screen bg-slate-100 border-t-4 border-black shadow-[inset_0_4px_8px_rgba(0,0,0,0.2)]">
+      {/* 상단 헤더 + 배경 */}
+      <div className="relative w-full">
+        <Header>
+          <Button
+            onClick={async () => await refetchPokemonData()}
+            background="red-500"
+          >
+            🔁 다시 뽑기
+          </Button>
+          <Button routerPath="/input" background={"white"}>
+            🏠 홈으로
+          </Button>
+        </Header>
+        {/* <img src="/pokeball.svg" className="w-28 h-auto " /> */}
+      </div>
+
+      <div className="max-w-xl mt-[72px] mx-auto bg-white border-2 border-black rounded-xl shadow-[4px_4px_0px_black] p-6 space-y-4 z-10 relative ">
+        <div className="w-full flex justify-center items-center p-4 ">
+          <img
+            src={`/pokeball_color.svg`}
+            alt="pokeball"
+            className="w-[180px] h-auto"
+          />
+        </div>
+        <div className="flex justify-center gap-2">
+          {Array.isArray(typeImages) &&
+            typeImages.map((img, idx) => (
+              <img key={idx} src={img} className="w-16 h-auto" />
+            ))}
+        </div>
+        <div className="text-center text-gray-800 text-base font-mono tracking-wide space-y-1">
+          {iljuDetail &&
+            iljuDetail.trait.map((trait, idx) => <p key={idx}>{trait}</p>)}
+        </div>
+      </div>
+
+      <div className="w-full mx-auto mt-12 px-4">
+        <h2 className="text-xl font-bold text-center mb-4  border-black pb-2 font-mono tracking-widest">
+          {username}님과 어울리는 포켓몬
+        </h2>
+        <div className="flex flex-wrap gap-8 items-center w-full justify-center">
+          {pokemons?.map((pokemon) => (
+            <PokemonCard key={pokemon.url} pokemon={pokemon} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/pokemon/PokemonCard.tsx
+++ b/src/components/pokemon/PokemonCard.tsx
@@ -1,22 +1,20 @@
 "use client";
 import { PokemonDetail } from "@custom-types/pokemonDetail";
 import { getTypeImage } from "@services/pokemonServices";
+import { useQuery } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 
 interface PokemonCardProps {
   pokemon: PokemonDetail;
 }
 function PokemonCard({ pokemon }: PokemonCardProps) {
-  const [typeImages, setTypeImages] = useState<string[]>([]);
-  useEffect(() => {
-    async function getTypes() {
-      const types = pokemon.types.map((type: any) => type.type.name);
-      const typeImages = await getTypeImage(types);
-      console.log(typeImages);
-      setTypeImages(typeImages.typeImages);
-    }
-    getTypes();
-  }, []);
+  const types = pokemon.types.map((type: any) => type.type.name);
+  const { data: typeImages } = useQuery({
+    queryKey: ["pokemonType", pokemon],
+    queryFn: () => getTypeImage(types),
+    enabled: !!types,
+  });
+
   return (
     <div
       key={pokemon.url}
@@ -33,9 +31,10 @@ function PokemonCard({ pokemon }: PokemonCardProps) {
         </div>
       </div>
       <div className="flex gap-2">
-        {typeImages.map((type: any) => (
-          <img src={type} className="w-16 h-auto" />
-        ))}
+        {Array.isArray(typeImages) &&
+          typeImages?.map((type: any) => (
+            <img src={type} className="w-16 h-auto" />
+          ))}
       </div>
     </div>
   );

--- a/src/components/pokemon/TalkingBox.tsx
+++ b/src/components/pokemon/TalkingBox.tsx
@@ -22,14 +22,18 @@ function TalkingBox({ ment, children }: TalkingBoxProps) {
           className="w-[90px] h-auto object-contain mr-4 shrink-0"
         />
         <div className="flex-1 text-center space-y-2 font-mono text-sm tracking-wide text-gray-700">
-          <p className="text-xl">{ment[mentIndex]}</p>
+          <p className="text-xl whitespace-pre-line text-center">
+            {ment[mentIndex]}
+          </p>
         </div>
-        <button
-          onClick={handleClickNext}
-          className="ml-4 px-6 py-2 bg-red-500 text-white text-sm font-bold rounded-full border-2 border-black shadow-[2px_2px_0px_black] hover:bg-red-600 transition-all duration-200"
-        >
-          Next
-        </button>
+        {mentIndex < ment.length - 1 && (
+          <button
+            onClick={handleClickNext}
+            className="ml-4 px-6 py-2 bg-red-500 text-white text-sm font-bold rounded-full border-2 border-black shadow-[2px_2px_0px_black] hover:bg-red-600 transition-all duration-200"
+          >
+            Next
+          </button>
+        )}
       </div>
 
       <div>{children}</div>

--- a/src/hooks/usePokemonByIlju.ts
+++ b/src/hooks/usePokemonByIlju.ts
@@ -1,14 +1,10 @@
 "use client";
-import { PokemonDetail } from "@custom-types/pokemonDetail";
-import { SajuProfile } from "@custom-types/sajuProfile";
-import { IljuDetailType } from "@lib/pokemon/getIljuDetail";
-import { getIljuByBirth } from "@lib/sajuUtils";
+
 import {
   getRandomPokemonByIlju,
   getTypeImage,
 } from "@services/pokemonServices";
 import { useQuery } from "@tanstack/react-query";
-import { useEffect, useMemo, useState } from "react";
 
 export default function usePokemonByIlju(ilju: string) {
   //사주정보를 바탕으로, 포켓몬에 매칭 정보 받아오는 쿼리
@@ -17,7 +13,7 @@ export default function usePokemonByIlju(ilju: string) {
     refetch: refetchPokemonData,
   } = useQuery({
     queryKey: ["ilju", ilju],
-    queryFn: () => getRandomPokemonByIlju(ilju),
+    queryFn: () => getRandomPokemonByIlju(ilju, 6),
     enabled: !!ilju,
   });
 
@@ -27,10 +23,6 @@ export default function usePokemonByIlju(ilju: string) {
     queryFn: () => getTypeImage(iljuDetail?.types),
     enabled: !!iljuDetail?.types,
   });
-
-  useEffect(() => {
-    console.log("hook 실행", ilju);
-  }, [ilju]);
 
   return {
     pokemons,

--- a/src/hooks/usePokemonByIlju.ts
+++ b/src/hooks/usePokemonByIlju.ts
@@ -1,0 +1,41 @@
+"use client";
+import { PokemonDetail } from "@custom-types/pokemonDetail";
+import { SajuProfile } from "@custom-types/sajuProfile";
+import { IljuDetailType } from "@lib/pokemon/getIljuDetail";
+import { getIljuByBirth } from "@lib/sajuUtils";
+import {
+  getRandomPokemonByIlju,
+  getTypeImage,
+} from "@services/pokemonServices";
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useMemo, useState } from "react";
+
+export default function usePokemonByIlju(ilju: string) {
+  //사주정보를 바탕으로, 포켓몬에 매칭 정보 받아오는 쿼리
+  const {
+    data: { pokemon: pokemons, iljuDetail } = {},
+    refetch: refetchPokemonData,
+  } = useQuery({
+    queryKey: ["ilju", ilju],
+    queryFn: () => getRandomPokemonByIlju(ilju),
+    enabled: !!ilju,
+  });
+
+  //사주 정보를 바탕으로 포켓몬 타입 이미지 받아오는 쿼리
+  const { data: typeImages } = useQuery({
+    queryKey: ["ilju-pokemonType", iljuDetail?.types],
+    queryFn: () => getTypeImage(iljuDetail?.types),
+    enabled: !!iljuDetail?.types,
+  });
+
+  useEffect(() => {
+    console.log("hook 실행", ilju);
+  }, [ilju]);
+
+  return {
+    pokemons,
+    iljuDetail,
+    typeImages,
+    refetchPokemonData,
+  };
+}

--- a/src/services/pokemonServices.ts
+++ b/src/services/pokemonServices.ts
@@ -14,17 +14,19 @@ export async function getRandomPokemonByIlju(ilju: string) {
     iljuDetail: IljuDetailType;
   } = await response.json();
 
-  console.log("출력:ㅣ", pokemonData);
   return pokemonData;
 }
 
-export async function getTypeImage(types: string[]) {
+export async function getTypeImage(
+  types: string[] | undefined
+): Promise<string[]> {
+  if (!types) throw new Error("types가 정의되지 않았습니다.");
   const response = await fetch("/api/pokemon/type-image", {
     method: "POST",
     body: JSON.stringify({
       types: types,
     }),
   });
-  const typeImages = await response.json();
+  const typeImages: string[] = await response.json();
   return typeImages;
 }

--- a/src/services/pokemonServices.ts
+++ b/src/services/pokemonServices.ts
@@ -1,12 +1,12 @@
 import { PokemonDetail } from "@custom-types/pokemonDetail";
 import { IljuDetailType } from "@lib/pokemon/getIljuDetail";
 
-export async function getRandomPokemonByIlju(ilju: string) {
+export async function getRandomPokemonByIlju(ilju: string, number: number) {
   const response = await fetch("/api/pokemon/pokemon-by-ilju", {
     method: "POST",
     body: JSON.stringify({
       ilju: ilju,
-      randomPokemonNumber: 6,
+      randomPokemonNumber: number,
     }),
   });
   const pokemonData: {

--- a/src/services/userServices.ts
+++ b/src/services/userServices.ts
@@ -1,0 +1,9 @@
+import { SajuProfile } from "@custom-types/sajuProfile";
+
+export async function setUserInfo(data: SajuProfile) {
+  await fetch("/api/user", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+}


### PR DESCRIPTION
- 전역 상태 관리로 유저 정보를 저장하려고 했으나, nextjs의 장점을 살려서 쿠키에 유저 정보를 저장하도록 로직 수정 
- 유저 정보가 없을 경우 보여줄 페이지 제작 
- 인풋 페이지에서 유저 정보를 쿠키에 저장 
- 결과페이지에서 유저 정보를 가져와서 props로 일주 정보를 넘겨줌 